### PR TITLE
update banned topics to include epo

### DIFF
--- a/mod_topics/moderated_topics.yml
+++ b/mod_topics/moderated_topics.yml
@@ -98,6 +98,7 @@ Banned_Topics:
     substances:
       - ['hGH', 'human growth hormone', 'somatropin', 'somatrem', 'gh']
       - ['Genotropin', 'Norditropin', 'Humatrope', 'Saizen', 'Omnitrope', 'Zomacton', 'Nutropin', 'Serostim']
+      - ['EPO', 'erythropoietin', 'Epogen', 'Procrit', 'Aranesp']
 
 
 Auto_Poof_Topics:


### PR DESCRIPTION
Adding to banned topics as governed by U.S. law (FDCA, 21 U.S.C. §333(e)):
`- ['EPO', 'erythropoietin', 'Epogen', 'Procrit', 'Aranesp']`